### PR TITLE
sqlalchemy url changed to a railway url

### DIFF
--- a/plantask/alembic.ini
+++ b/plantask/alembic.ini
@@ -63,7 +63,7 @@ version_path_separator = os
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql://postgres:koch123@localhost:5432/plantask
+sqlalchemy.url = postgresql://postgres:hqDGUoMpypystmdWLOYHdzOMrABijDKi@hopper.proxy.rlwy.net:32534/railway
 
 
 [post_write_hooks]

--- a/plantask/development.ini
+++ b/plantask/development.ini
@@ -14,7 +14,7 @@ pyramid.default_locale_name = en
 pyramid.includes =
     pyramid_debugtoolbar
 
-sqlalchemy.url = sqlite:///%(here)s/plantask.sqlite
+sqlalchemy.url = postgresql://postgres:hqDGUoMpypystmdWLOYHdzOMrABijDKi@hopper.proxy.rlwy.net:32534/railway
 
 retry.attempts = 3
 


### PR DESCRIPTION
sqlalchemy.url changed from localhost to a railway hosy